### PR TITLE
Include ghost cells when multiplying or dividing rho0 for anelastic

### DIFF
--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -333,7 +333,7 @@ void incflo::ApplyProjection(
             for (int idim = 0; idim < velocity.num_comp(); ++idim) {
                 amrex::Multiply(
                     velocity(lev), (*ref_density)(lev), 0, idim,
-                    density[lev]->nComp(), 0);
+                    density[lev]->nComp(), 1);
             }
         }
     }
@@ -405,7 +405,7 @@ void incflo::ApplyProjection(
             for (int idim = 0; idim < velocity.num_comp(); ++idim) {
                 amrex::Divide(
                     velocity(lev), (*ref_density)(lev), 0, idim,
-                    density[lev]->nComp(), 0);
+                    density[lev]->nComp(), 1);
             }
         }
     }


### PR DESCRIPTION
## Summary

Include ghost cells when multiplying or dividing rho0 for anelastic. Not including them would be incorrect.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
